### PR TITLE
Passthrough Client Request and Cloudinary Response Headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ async function serveAsset(event) {
   let response = await cache.match(event.request)
   if (!response) {
     const cloudinaryURL = `${CLOUD_URL}${url.pathname}`;
-    response = await fetch(cloudinaryURL)
+    response = await fetch(cloudinaryURL, { headers: event.request.headers })
     // Cache for however long, here is 4 hours.
     const headers = { "cache-control": "public, max-age=14400" }
     response = new Response(response.body, { ...response, headers })

--- a/index.js
+++ b/index.js
@@ -14,7 +14,9 @@ async function serveAsset(event) {
     const cloudinaryURL = `${CLOUD_URL}${url.pathname}`;
     response = await fetch(cloudinaryURL, { headers: event.request.headers })
     // Cache for however long, here is 4 hours.
-    const headers = { "cache-control": "public, max-age=14400" }
+    const headers = new Headers(response.headers);
+    headers.set("cache-control", `public, max-age=14400`);
+    headers.set("vary", "Accept");
     response = new Response(response.body, { ...response, headers })
     event.waitUntil(cache.put(event.request, response.clone()))
   }


### PR DESCRIPTION
This PR passes the client's request headers to Cloudinary and returns Cloudinary's response headers back to the client.

The client's request headers were not being sent to Cloudinary and without these the `format: auto` (`f_auto` on the URL) feature never works. Cloudinary uses the `Accept` header (and possibly others) to determine which image format to return to the client (e.g., `webp`, `jpeg`, etc.). Since this wasn't getting sent, the format was always coming back as `jpeg` which isn't always the most efficient for browser that support newer formats.

With the client headers being passed through, I adjusted the `Vary` header to ensure distinct caches were created based on `Accept` header for each image format. It is also sometimes useful to see the Cloudinary response headers to understand how certain "auto" transformations were applied. These will now pass though back to the client with the `Cache-Control` and `Vary` headers overridden appropriately.